### PR TITLE
feat: implement car file support

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ export class Cluster {
     url.searchParams.set('cid-version', 1)
     setPinOptions(options, url.searchParams)
 
+    if (file.type === 'application/car') {
+      url.searchParams.set('format', 'car')
+    }
+
     const headers = this.options.headers
     const response = await fetch(url.toString(), { method: 'POST', headers, body })
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "@web-std/fetch": "^1.0.0",
     "@web-std/file": "^1.0.1",
     "@web-std/form-data": "^2.0.0",
-    "standard": "^16.0.3"
+    "standard": "^16.0.3",
+    "@ipld/car": "^1.0.1",
+    "multiformats": "^7.0.0",
+    "@ipld/dag-cbor": "^5.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Implements support for car imports as per https://github.com/ipfs/ipfs-cluster/pull/1343

Sets format to `car` if blob / file mime type is set to `application/car`. This is needed for https://github.com/ipfs-shipyard/nft.storage/pull/56