### PR TITLE
fix: hash consistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ export class Cluster {
 
     const url = new URL('add', this.url)
     url.searchParams.set('cid-version', 1)
+    url.searchParams.set('raw-leaves', true)
     setPinOptions(options, url.searchParams)
 
     if (file.type === 'application/car') {
@@ -67,6 +68,7 @@ export class Cluster {
 
     const url = new URL('add', this.url)
     url.searchParams.set('cid-version', 1)
+    url.searchParams.set('raw-leaves', true)
     url.searchParams.set('wrap-with-directory', true)
     setPinOptions(options, url.searchParams)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "devDependencies": {
         "@ipld/car": "^1.0.1",
         "@ipld/dag-cbor": "^5.0.0",
-        "@web-std/fetch": "^1.0.0",
-        "@web-std/file": "^1.0.1",
-        "@web-std/form-data": "^2.0.0",
-        "multiformats": "^7.0.0",
+        "@web-std/fetch": "^2.0.0",
+        "@web-std/file": "^1.1.0",
+        "@web-std/form-data": "^2.1.0",
+        "multiformats": "^8.0.6",
         "standard": "^16.0.3"
       }
     },
@@ -28,18 +28,18 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
       "dev": true
     },
     "node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -128,32 +128,26 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-1.0.1.tgz",
-      "integrity": "sha512-r8y+utMM+acmrVfwH1n+l1wLRacyqo68U+7uOht4Ro6+bsD+q2MKXoYrI/7yl7S5C5Ik/I8MEuprhgOnSxz5/g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-1.0.6.tgz",
+      "integrity": "sha512-YWiQ0SrtzDw/d11GnW1X1MOhjA+HdDshMo7HC9nCKplxBWsdEx6cWZFP6UNrdCCHMdGQIHVo270bROgKTb1kHg==",
       "dev": true,
       "dependencies": {
         "@ipld/dag-cbor": "^5.0.0",
         "@types/varint": "^6.0.0",
-        "multiformats": "^7.0.0",
+        "multiformats": "^8.0.3",
         "varint": "^6.0.0"
       }
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.0.tgz",
-      "integrity": "sha512-5jsM3W38Wk1mrqtrD+DmJpgLJgDrXQ9H3LU8inDKZvpOma0srNA35xcc21N1mGRDZPmfF2H35SdTYaUtAK35Zg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.5.tgz",
+      "integrity": "sha512-nSWGvqhwE9nHsrBx8YL4TiwhsitLhJ54Md5BMCUdK+s10QPxYsO7l/rRxU9bLV/L13WUTfLEll2K3Q2ijlZCWw==",
       "dev": true,
       "dependencies": {
         "cborg": "^1.2.1",
-        "multiformats": "^7.0.0"
+        "multiformats": "^8.0.3"
       }
-    },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
-      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -162,9 +156,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
       "dev": true
     },
     "node_modules/@types/varint": {
@@ -177,49 +171,46 @@
       }
     },
     "node_modules/@web-std/blob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.0.0.tgz",
-      "integrity": "sha512-i4JdX5sli14KQra9wYo2a/wap5SICp4c20EdGTzPDxUbXLPrPIsH5IplUizKeBXNRAtxKDenp+kCNukVs3FyNA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.1.0.tgz",
+      "integrity": "sha512-XarzlypyLoaSZTdh+y/uBwGwayHXp++Q0CcgppfMxpm3VnbcJseMuXMZQK9OFDTiGpasoVwICgBL/8Rc6/B1fw==",
       "dev": true,
       "dependencies": {
-        "web-encoding": "1.1.0",
-        "web-streams-polyfill": "2.1.1"
+        "web-encoding": "1.1.5",
+        "web-streams-polyfill": "3.0.3"
       }
     },
     "node_modules/@web-std/fetch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-1.0.0.tgz",
-      "integrity": "sha512-ghp1XUrJf1Ue4hSMC5In6b1osL+iYmyqIFNS4c/3sIsBjX3j6doWG1hXCEQYk88OwXLbSzAIc6q0mBnIbkUVjg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-2.0.1.tgz",
+      "integrity": "sha512-aCstfrPOHrAvU65a24Dxjy1LU7RMXOe54GuwA978ln6Fy1K9QPs3ORR71ikaQXX06cXfgu3NDQelhMYlTRrWrA==",
       "dev": true,
       "dependencies": {
+        "@web-std/blob": "^2.1.0",
         "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
+        "web-streams-polyfill": "^3.0.2"
       },
       "engines": {
         "node": "^10.17 || >=12.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/@web-std/file": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.0.1.tgz",
-      "integrity": "sha512-XAgUci2QDWb+HLtZnujP4kBmW4aYGYHAVimN4hn6tK0tMKsZi3e1teguy/e2ZXdimvrXMq8Dt9UPHUdRcY28iQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.0.tgz",
+      "integrity": "sha512-VyKHE0eN713xBoRe7wrUjamct1KoALrkxCPEHiAusdBvOw7bSu4nmP+1i7b8L0cBUDawUEQyT7+7kPIykUla6A==",
       "dev": true,
       "dependencies": {
-        "@web-std/blob": "2.0.0"
+        "@web-std/blob": "^2.1.0"
       }
     },
     "node_modules/@web-std/form-data": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-2.0.0.tgz",
-      "integrity": "sha512-zgLBe6QZUhl3Mk0jKJ9vWLdv9sykq7lVRHazQyJw4fZOVYltJ4WdJsxC+Jd2br+qkWJTppNORzyMK/0ayy4AOw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-2.1.0.tgz",
+      "integrity": "sha512-gKVx2I/mu0KK6s4DDACfpUQTIGCim6ShvOXMUONnzB3VoR7qTX2oh5YJjXiDKoR92ZbBZYxAhKO+jfxbMFQpvw==",
       "dev": true,
       "dependencies": {
-        "web-encoding": "1.1.0",
-        "web-streams-polyfill": "2.1.1"
+        "web-encoding": "1.1.5",
+        "web-streams-polyfill": "3.0.3"
       }
     },
     "node_modules/@zxing/text-encoding": {
@@ -308,6 +299,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "node_modules/array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -371,31 +368,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "dependencies": {
+        "array-filter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -405,30 +397,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/call-bind": {
@@ -454,18 +422,18 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.2.1.tgz",
-      "integrity": "sha512-eA14hhjU6a9QxCvam/hdRl5LMLfqB1YGG/VA5woI5LxVDjh7kDiRxFp/uSfYQjAGVuk2BvSjx7L60u+B1k3gGw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.1.tgz",
+      "integrity": "sha512-neK2ovbsVY9KFKDUdwifRO0U6p0Y7mZ/08nPgPEV20mABkui+9Fiic63eiPg1TnWuD+Vzjmtp2xUWEdv+AtgFg==",
       "dev": true,
       "bin": {
         "cborg": "cli.js"
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -476,22 +444,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cids": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.6.tgz",
-      "integrity": "sha512-5P+Jas2bVpjiHibp/SOwKY+v7JhAjTChaAZN+vCIrsWXn/JZV0frX22Vp5zZgEyJRPco79pX+yNQ2S3LkRukHQ==",
-      "dev": true,
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.1",
-        "uint8arrays": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -595,19 +547,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "webidl-conversions": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/emoji-regex": {
@@ -823,12 +762,12 @@
       "dev": true
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
       "dev": true,
       "dependencies": {
-        "debug": "^2.6.9",
+        "debug": "^3.2.7",
         "pkg-dir": "^2.0.0"
       },
       "engines": {
@@ -836,19 +775,13 @@
       }
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
-    },
-    "node_modules/eslint-module-utils/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
     },
     "node_modules/eslint-plugin-es": {
       "version": "3.0.1",
@@ -1046,9 +979,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1168,18 +1101,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "node_modules/fetch-blob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.1.tgz",
-      "integrity": "sha512-Uf+gxPCe1hTOFXwkxYyckn8iUSk6CFXGy5VENZKifovUTZC9eUODWSBhOBS7zICGrAetKzdwLMr85KhIcePMAQ==",
-      "dev": true,
-      "engines": {
-        "node": "^10.17.0 || >=12.3.0"
-      },
-      "peerDependencies": {
-        "domexception": "^2.0.1"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -1222,6 +1143,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "node_modules/foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "node_modules/fs.realpath": {
@@ -1269,9 +1196,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -1369,26 +1296,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1453,6 +1360,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1460,21 +1382,21 @@
       "dev": true
     },
     "node_modules/is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1496,9 +1418,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -1508,9 +1430,9 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -1535,6 +1457,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -1562,9 +1496,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -1574,13 +1508,13 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1590,9 +1524,9 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -1602,11 +1536,30 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
       "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       },
       "engines": {
@@ -1797,64 +1750,10 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "dev": true,
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
-      "dev": true,
-      "dependencies": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      }
-    },
-    "node_modules/multicodec/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-      "dev": true
-    },
     "node_modules/multiformats": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-7.0.0.tgz",
-      "integrity": "sha512-B39Rk603Ri8AKHCVhRGwZk+MfxqcxsDxgvja801cMoPJRk4BvS6kxDr5C0331JvnQDK4phJBfMQjcTlwfOAImw==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "cids": "^1.1.6"
-      }
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "dev": true,
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -1894,9 +1793,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2383,6 +2282,26 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2501,9 +2420,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
       "dev": true
     },
     "node_modules/sprintf-js": {
@@ -2755,15 +2674,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/uint8arrays": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.5.tgz",
-      "integrity": "sha512-CSR7AO+4AHUeSOnZ/NBNCElDeWfRh9bXtOck27083kc7SznmmHIhNEkEOCQOn0wvrIMjS3IH0TNLR16vuc46mA==",
-      "dev": true,
-      "dependencies": {
-        "multibase": "^4.0.1"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -2786,6 +2696,20 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -2811,31 +2735,24 @@
       "dev": true
     },
     "node_modules/web-encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
-      "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
       "dev": true,
+      "dependencies": {
+        "util": "^0.12.3"
+      },
       "optionalDependencies": {
         "@zxing/text-encoding": "0.9.0"
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
+      "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/which": {
@@ -2864,6 +2781,27 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2923,18 +2861,18 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -3010,32 +2948,26 @@
       }
     },
     "@ipld/car": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-1.0.1.tgz",
-      "integrity": "sha512-r8y+utMM+acmrVfwH1n+l1wLRacyqo68U+7uOht4Ro6+bsD+q2MKXoYrI/7yl7S5C5Ik/I8MEuprhgOnSxz5/g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-1.0.6.tgz",
+      "integrity": "sha512-YWiQ0SrtzDw/d11GnW1X1MOhjA+HdDshMo7HC9nCKplxBWsdEx6cWZFP6UNrdCCHMdGQIHVo270bROgKTb1kHg==",
       "dev": true,
       "requires": {
         "@ipld/dag-cbor": "^5.0.0",
         "@types/varint": "^6.0.0",
-        "multiformats": "^7.0.0",
+        "multiformats": "^8.0.3",
         "varint": "^6.0.0"
       }
     },
     "@ipld/dag-cbor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.0.tgz",
-      "integrity": "sha512-5jsM3W38Wk1mrqtrD+DmJpgLJgDrXQ9H3LU8inDKZvpOma0srNA35xcc21N1mGRDZPmfF2H35SdTYaUtAK35Zg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.5.tgz",
+      "integrity": "sha512-nSWGvqhwE9nHsrBx8YL4TiwhsitLhJ54Md5BMCUdK+s10QPxYsO7l/rRxU9bLV/L13WUTfLEll2K3Q2ijlZCWw==",
       "dev": true,
       "requires": {
         "cborg": "^1.2.1",
-        "multiformats": "^7.0.0"
+        "multiformats": "^8.0.3"
       }
-    },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
-      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -3044,9 +2976,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
       "dev": true
     },
     "@types/varint": {
@@ -3059,42 +2991,43 @@
       }
     },
     "@web-std/blob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.0.0.tgz",
-      "integrity": "sha512-i4JdX5sli14KQra9wYo2a/wap5SICp4c20EdGTzPDxUbXLPrPIsH5IplUizKeBXNRAtxKDenp+kCNukVs3FyNA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.1.0.tgz",
+      "integrity": "sha512-XarzlypyLoaSZTdh+y/uBwGwayHXp++Q0CcgppfMxpm3VnbcJseMuXMZQK9OFDTiGpasoVwICgBL/8Rc6/B1fw==",
       "dev": true,
       "requires": {
-        "web-encoding": "1.1.0",
-        "web-streams-polyfill": "2.1.1"
+        "web-encoding": "1.1.5",
+        "web-streams-polyfill": "3.0.3"
       }
     },
     "@web-std/fetch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-1.0.0.tgz",
-      "integrity": "sha512-ghp1XUrJf1Ue4hSMC5In6b1osL+iYmyqIFNS4c/3sIsBjX3j6doWG1hXCEQYk88OwXLbSzAIc6q0mBnIbkUVjg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-2.0.1.tgz",
+      "integrity": "sha512-aCstfrPOHrAvU65a24Dxjy1LU7RMXOe54GuwA978ln6Fy1K9QPs3ORR71ikaQXX06cXfgu3NDQelhMYlTRrWrA==",
       "dev": true,
       "requires": {
+        "@web-std/blob": "^2.1.0",
         "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
+        "web-streams-polyfill": "^3.0.2"
       }
     },
     "@web-std/file": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.0.1.tgz",
-      "integrity": "sha512-XAgUci2QDWb+HLtZnujP4kBmW4aYGYHAVimN4hn6tK0tMKsZi3e1teguy/e2ZXdimvrXMq8Dt9UPHUdRcY28iQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.0.tgz",
+      "integrity": "sha512-VyKHE0eN713xBoRe7wrUjamct1KoALrkxCPEHiAusdBvOw7bSu4nmP+1i7b8L0cBUDawUEQyT7+7kPIykUla6A==",
       "dev": true,
       "requires": {
-        "@web-std/blob": "2.0.0"
+        "@web-std/blob": "^2.1.0"
       }
     },
     "@web-std/form-data": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-2.0.0.tgz",
-      "integrity": "sha512-zgLBe6QZUhl3Mk0jKJ9vWLdv9sykq7lVRHazQyJw4fZOVYltJ4WdJsxC+Jd2br+qkWJTppNORzyMK/0ayy4AOw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/form-data/-/form-data-2.1.0.tgz",
+      "integrity": "sha512-gKVx2I/mu0KK6s4DDACfpUQTIGCim6ShvOXMUONnzB3VoR7qTX2oh5YJjXiDKoR92ZbBZYxAhKO+jfxbMFQpvw==",
       "dev": true,
       "requires": {
-        "web-encoding": "1.1.0",
-        "web-streams-polyfill": "2.1.1"
+        "web-encoding": "1.1.5",
+        "web-streams-polyfill": "3.0.3"
       }
     },
     "@zxing/text-encoding": {
@@ -3159,6 +3092,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -3201,16 +3140,19 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "brace-expansion": {
@@ -3221,16 +3163,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "call-bind": {
@@ -3250,31 +3182,19 @@
       "dev": true
     },
     "cborg": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.2.1.tgz",
-      "integrity": "sha512-eA14hhjU6a9QxCvam/hdRl5LMLfqB1YGG/VA5woI5LxVDjh7kDiRxFp/uSfYQjAGVuk2BvSjx7L60u+B1k3gGw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.1.tgz",
+      "integrity": "sha512-neK2ovbsVY9KFKDUdwifRO0U6p0Y7mZ/08nPgPEV20mABkui+9Fiic63eiPg1TnWuD+Vzjmtp2xUWEdv+AtgFg==",
       "dev": true
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      }
-    },
-    "cids": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.6.tgz",
-      "integrity": "sha512-5P+Jas2bVpjiHibp/SOwKY+v7JhAjTChaAZN+vCIrsWXn/JZV0frX22Vp5zZgEyJRPco79pX+yNQ2S3LkRukHQ==",
-      "dev": true,
-      "requires": {
-        "multibase": "^4.0.1",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.1",
-        "uint8arrays": "^2.1.3"
       }
     },
     "color-convert": {
@@ -3352,16 +3272,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "webidl-conversions": "^5.0.0"
       }
     },
     "emoji-regex": {
@@ -3516,29 +3426,23 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
+        "debug": "^3.2.7",
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -3692,9 +3596,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
     "espree": {
@@ -3786,13 +3690,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fetch-blob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.1.tgz",
-      "integrity": "sha512-Uf+gxPCe1hTOFXwkxYyckn8iUSk6CFXGy5VENZKifovUTZC9eUODWSBhOBS7zICGrAetKzdwLMr85KhIcePMAQ==",
-      "dev": true,
-      "requires": {}
-    },
     "file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -3826,6 +3723,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "fs.realpath": {
@@ -3864,9 +3767,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -3934,12 +3837,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -3989,6 +3886,15 @@
         "side-channel": "^1.0.4"
       }
     },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3996,18 +3902,18 @@
       "dev": true
     },
     "is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
       "dev": true
     },
     "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-callable": {
@@ -4017,18 +3923,18 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
       "dev": true
     },
     "is-extglob": {
@@ -4041,6 +3947,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==",
       "dev": true
     },
     "is-glob": {
@@ -4059,33 +3971,46 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       }
     },
     "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
       "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       }
     },
@@ -4240,61 +4165,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "dev": true,
-      "requires": {
-        "@multiformats/base-x": "^4.0.1"
-      }
-    },
-    "multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
-      "dev": true,
-      "requires": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-          "dev": true
-        }
-      }
-    },
     "multiformats": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-7.0.0.tgz",
-      "integrity": "sha512-B39Rk603Ri8AKHCVhRGwZk+MfxqcxsDxgvja801cMoPJRk4BvS6kxDr5C0331JvnQDK4phJBfMQjcTlwfOAImw==",
-      "dev": true,
-      "requires": {
-        "buffer": "^6.0.3",
-        "cids": "^1.1.6"
-      }
-    },
-    "multihashes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-      "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-      "dev": true,
-      "requires": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-          "dev": true
-        }
-      }
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4329,9 +4204,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
       "dev": true
     },
     "object-keys": {
@@ -4688,6 +4563,12 @@
         "glob": "^7.1.3"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -4787,9 +4668,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
       "dev": true
     },
     "sprintf-js": {
@@ -4964,15 +4845,6 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
-    "uint8arrays": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.5.tgz",
-      "integrity": "sha512-CSR7AO+4AHUeSOnZ/NBNCElDeWfRh9bXtOck27083kc7SznmmHIhNEkEOCQOn0wvrIMjS3IH0TNLR16vuc46mA==",
-      "dev": true,
-      "requires": {
-        "multibase": "^4.0.1"
-      }
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -4992,6 +4864,20 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "util": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
       }
     },
     "v8-compile-cache": {
@@ -5017,26 +4903,20 @@
       "dev": true
     },
     "web-encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
-      "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
       "dev": true,
       "requires": {
-        "@zxing/text-encoding": "0.9.0"
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
       }
     },
     "web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
+      "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "dev": true,
-      "peer": true
     },
     "which": {
       "version": "2.0.2",
@@ -5058,6 +4938,21 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@web-std/fetch": "^2.0.0",
     "@web-std/file": "^1.1.0",
     "@web-std/form-data": "^2.1.0",
-    "multiformats": "^7.0.0",
+    "multiformats": "^8.0.6",
     "standard": "^16.0.3"
   },
   "standard": {

--- a/test.js
+++ b/test.js
@@ -22,8 +22,8 @@ const tests = {
     const result = await cluster.add(file)
     console.log(result)
     assert.strictEqual(result.name, file.name)
-    assert.strictEqual(result.cid, 'bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu')
-    assert.strictEqual(result.size, 11)
+    assert.strictEqual(result.cid, 'bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy')
+    assert.strictEqual(result.size, 3)
   },
 
   async 'adds a directory of files' () {
@@ -36,17 +36,17 @@ const tests = {
     console.log(dir)
 
     assert.strictEqual(dir[0].name, files[0].name)
-    assert.strictEqual(dir[0].size, 11)
-    assert.strictEqual(dir[0].cid, 'bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu')
+    assert.strictEqual(dir[0].size, 3)
+    assert.strictEqual(dir[0].cid, 'bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy')
 
     assert.strictEqual(dir[1].name, files[1].name)
-    assert.strictEqual(dir[1].size, 11)
-    assert.strictEqual(dir[1].cid, 'bafybeidsnna57jpm2ttwaydwak25qpkxafrg4cnrjsfqipbcqxlsfobjje')
+    assert.strictEqual(dir[1].size, 3)
+    assert.strictEqual(dir[1].cid, 'bafkreih43yvs5w5fnp2aqya7w4q75g24gogrb3sct2qe7lsvcg3i7p4pxe')
 
     // (wrapper directory)
     assert.strictEqual(dir[2].name, '')
-    assert.strictEqual(dir[2].size, 128)
-    assert.strictEqual(dir[2].cid, 'bafybeihdqdewefamqnvu7ih6t7pdam4wisengifqg3fv4jin76ax63hl3i')
+    assert.strictEqual(dir[2].size, 112)
+    assert.strictEqual(dir[2].cid, 'bafybeidhbfwu4j2zckkqd42azgxm7hlvjjqj7dunvv7o7c3avyrhgtvppm')
   },
 
   async 'import dag via car file' () {


### PR DESCRIPTION
See https://github.com/ipfs/ipfs-cluster/issues/1358

This PR explicitly sets `?raw-leaves=true` (in addition to setting `?cid-version=1`) in order to have interop with IPFS add (also gives us a saving in bytes).

Tests updated with fixture CIDs generated by adding the same content directly to IPFS.