### PR TITLE
feat: implement abort support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,60 +2,70 @@ export class Cluster {
   /**
    * Create a new instance of the cluster client.
    */
-  constructor (url: URL|string, options?: { headers?: Record<string, string> })
+  constructor(url: URL | string, options?: { headers?: Record<string, string> })
   /**
    * Import a file to the cluster. First argument must be a `File` or `Blob`.
    * CAR files are supported with blob `type` set to `application/car`.
    * Note: by default this module uses v1 CIDs and raw leaves enabled.
    */
-  add (file: File|Blob, options?: AddParams): Promise<AddResponse>
+  add(file: File | Blob, options?: AddParams): Promise<AddResponse>
   /**
    * Imports multiple files to the cluster. First argument must be an array of
    * `File` or `Blob`. Note: by default this module uses v1 CIDs and raw leaves
    * enabled.
    */
-  addDirectory (file: Iterable<File|Blob>, options?: AddParams): Promise<AddDirectoryResponse>
+  addDirectory(
+    file: Iterable<File | Blob>,
+    options?: AddParams
+  ): Promise<AddDirectoryResponse>
   /**
    * Tracks a CID with the given replication factor and a name for
    * human-friendliness.
    */
-  pin (cid: string, options?: PinOptions): Promise<PinResponse>
+  pin(cid: string, options?: PinOptions): Promise<PinResponse>
   /**
    * Untracks a CID from cluster.
    */
-  unpin (cid: string): Promise<PinResponse>
+  unpin(cid: string): Promise<PinResponse>
   /**
    * Returns the current IPFS state for a given CID.
    */
-  status (cid: string, options?: StatusOptions): Promise<StatusResponse>
+  status(cid: string, options?: StatusOptions): Promise<StatusResponse>
   /**
    * Returns the current allocation for a given CID.
    */
-  allocation (cid: string): Promise<PinResponse>
+  allocation(cid: string, options?: RequestOptions): Promise<PinResponse>
   /**
    * Re-triggers pin or unpin IPFS operations for a CID in error state.
    */
-  recover (cid: string, options?: RecoverOptions): Promise<StatusResponse>
+  recover(cid: string, options?: RecoverOptions): Promise<StatusResponse>
   /**
    * Get a list of metric types known to the peer.
    */
-  metricNames (): Promise<string[]>
+  metricNames(options?: RequestOptions): Promise<string[]>
+}
+
+export interface RequestOptions {
+  /**
+   * If provided, corresponding request will be aborted when signalled.
+   */
+  signal?: AbortSignal
 }
 
 export type AddResponse = {
   cid: string
   name?: string
-  size?: number|string
-  bytes?: number|string
+  size?: number | string
+  bytes?: number | string
 }
 
 export type AddDirectoryResponse = AddResponse[]
 
-export type PinOptions = {
+export interface PinOptions extends RequestOptions {
   replicationFactorMin?: number
   replicationFactorMax?: number
   name?: string
-  mode?: 'recursive'|'direct'
+  mode?: 'recursive' | 'direct'
   shardSize?: number
   /**
    * The peers to which this pin should be allocated.
@@ -79,7 +89,7 @@ export type IPFSAddParams = {
   chunker?: string
   rawLeaves?: boolean
   progress?: boolean
-  cidVersion?: 0|1
+  cidVersion?: 0 | 1
   hashFun?: string
   noCopy?: boolean
 }
@@ -88,15 +98,16 @@ export type IPFSAddParams = {
  * Contains all of the configurable parameters needed to specify the importing
  * process of a file being added to an IPFS Cluster.
  */
-export type AddParams = PinOptions & IPFSAddParams & {
-  local?: boolean
-  recursive?: boolean
-  hidden?: boolean
-  wrap?: boolean
-  shard?: boolean
-  streamChannels?: boolean
-  format?: string
-}
+export type AddParams = PinOptions &
+  IPFSAddParams & {
+    local?: boolean
+    recursive?: boolean
+    hidden?: boolean
+    wrap?: boolean
+    shard?: boolean
+    streamChannels?: boolean
+    format?: string
+  }
 
 export enum PinType {
   /**
@@ -133,7 +144,7 @@ export type PinResponse = {
   replicationFactorMin: number
   replicationFactorMax: number
   name: string
-  mode: 'recursive'|'direct'
+  mode: 'recursive' | 'direct'
   shardSize: number
   /**
    * The peers to which this pin is allocated.
@@ -165,7 +176,7 @@ export type PinResponse = {
   reference?: string
 }
 
-export type StatusOptions = {
+export interface StatusOptions extends RequestOptions {
   local?: boolean
 }
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,12 @@ export class Cluster {
     }
 
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { method: 'POST', headers, body })
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      body,
+      signal: options.signal
+    })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -74,7 +79,12 @@ export class Cluster {
     url.searchParams.set('wrap-with-directory', true)
 
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { method: 'POST', headers, body })
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      body,
+      signal: options.signal
+    })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -98,7 +108,11 @@ export class Cluster {
     setPinOptions(options, url.searchParams)
 
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { method: 'POST', headers })
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      signal: options.signal
+    })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -110,13 +124,18 @@ export class Cluster {
 
   /**
    * @param {string} cid CID or IPFS/IPNS path to unpin from the cluster.
+   * @param {import('./index').RequestOptions} [options]
    * @returns {Promise<import('./index').PinResponse>}
    */
-  async unpin (cid) {
+  async unpin (cid, { signal } = {}) {
     const path = cid.startsWith('/') ? `pins${cid}` : `pins/${cid}`
     const url = new URL(path, this.url)
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { method: 'DELETE', headers })
+    const response = await fetch(url.toString(), {
+      method: 'DELETE',
+      headers,
+      signal
+    })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -131,16 +150,15 @@ export class Cluster {
    * @param {import('./index').StatusOptions} [options]
    * @returns {Promise<import('./index').StatusResponse>}
    */
-  async status (cid, options) {
+  async status (cid, { local, signal } = {}) {
     const url = new URL(`pins/${encodeURIComponent(cid)}`, this.url)
 
-    options = options || {}
-    if (options.local != null) {
-      url.searchParams.set('local', options.local)
+    if (local != null) {
+      url.searchParams.set('local', local)
     }
 
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { headers })
+    const response = await fetch(url.toString(), { headers, signal })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -159,12 +177,13 @@ export class Cluster {
 
   /**
    * @param {string} cid The CID to get pin status information for.
+   * @param {import('./index').RequestOptions} [options]
    * @returns {Promise<import('./index').PinResponse>}
    */
-  async allocation (cid) {
+  async allocation (cid, { signal } = {}) {
     const url = new URL(`allocations/${encodeURIComponent(cid)}`, this.url)
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { headers })
+    const response = await fetch(url.toString(), { headers, signal })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -179,16 +198,19 @@ export class Cluster {
    * @param {import('./index').RecoverOptions} [options]
    * @returns {Promise<import('./index').StatusResponse>}
    */
-  async recover (cid, options) {
+  async recover (cid, { local, signal } = {}) {
     const url = new URL(`pins/${encodeURIComponent(cid)}/recover`, this.url)
 
-    options = options || {}
-    if (options.local != null) {
-      url.searchParams.set('local', options.local)
+    if (local != null) {
+      url.searchParams.set('local', local)
     }
 
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { method: 'POST', headers })
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers,
+      signal
+    })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })
@@ -206,12 +228,13 @@ export class Cluster {
   }
 
   /**
+   * @param {import('./index').RequestOptions} [options]
    * @returns {Promise<string[]>}
    */
-  async metricNames () {
+  async metricNames ({ signal } = {}) {
     const url = new URL('monitor/metrics', this.url)
     const headers = this.options.headers
-    const response = await fetch(url.toString(), { headers })
+    const response = await fetch(url.toString(), { headers, signal })
 
     if (!response.ok) {
       throw Object.assign(new Error(`${response.status}: ${response.statusText}`), { response })

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
       "*.ts"
     ]
   },
+  "prettier": {
+    "singleQuote": true,
+    "semi": false,
+    "trailingComma": "none"
+  },
   "eslintConfig": {
     "extends": "standard"
   },


### PR DESCRIPTION
This change just allows passing `AbortSignal` instance so that requests could be cancelled as needed. This would help unblocking niftysave until we can figure out https://github.com/protocol/bifrost-infra/issues/1335