### PR TITLE
fix: default fetch method to GET

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -299,7 +299,7 @@ const request = async (
   }
 
   const response = await fetch(endpoint.href, {
-    method,
+    method: method || 'GET',
     headers,
     body,
     signal


### PR DESCRIPTION
Some `fetch` implementations actually break when receiving `undefined`.

```
TypeError: 'undefined' is not a valid HTTP method.
    at new Request (/Users/alan/Code/web3-storage/web3.storage/node_modules/undici/lib/fetch/request.js:340:15)
    at new Request (/Users/alan/Code/web3-storage/web3.storage/node_modules/@miniflare/core/dist/src/index.js:636:13)
    at upgradingFetch (/Users/alan/Code/web3-storage/web3.storage/node_modules/@miniflare/web-sockets/dist/src/index.js:225:19)
    at WebSocketPlugin.<anonymous> (/Users/alan/Code/web3-storage/web3.storage/node_modules/@miniflare/core/dist/src/index.js:927:21)
    at fetch (/Users/alan/Code/web3-storage/web3.storage/node_modules/@miniflare/web-sockets/dist/src/index.js:295:48)
    at request (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:54426:26)
    at status (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:54374:22)
    at Cluster.status (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:54459:12)
    at getPins (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:59921:30)
    at addToCluster (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:60059:22)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 0)
    at async handleCarUpload (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:60006:38)
    at async /Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:46384:22
    at async Object.handle (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:2046:22)
    at async Object.fetch (/Users/alan/Code/web3-storage/web3.storage/packages/api/dist/index.mjs:63932:14)
    at async EventTarget.[kDispatchFetch] (/Users/alan/Code/web3-storage/web3.storage/node_modules/@miniflare/core/dist/src/index.js:1177:13)
    at async Server.<anonymous> (/Users/alan/Code/web3-storage/web3.storage/node_modules/@miniflare/http-server/dist/src/index.js:464:20)
```