### PR TITLE
feat: add statusAll method

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This library is **WIP** and not _all_ cluster HTTP API methods are available yet
 - `recoverAll`
 - `repoGC`
 - [`status`](#status)
-- `statusAll`
+- [`statusAll`](#statusall)
 - `version`
 - [`unpin`](#unpin)
 - `unpinPath`
@@ -169,6 +169,37 @@ for (const [clusterPeerID, pinInfo] of Object.entries(status.peerMap)) {
   // 12D3KooWKiebn7GqPvjqjKARnm47Xoez6f1civBEWxef3u5G6UdM: pinned
   // 12D3KooWLKdPdFx5UpPNwoVmMXsLULCDegAqXZ7RAgpKuPSMKoSS: pinned
 }
+```
+
+### `statusAll`
+
+Status of all tracked CIDs.
+
+```js
+const statuses = await cluster.statusAll()
+for (const status of statuses) {
+  console.log(`${status.cid}:`)
+  for (const [clusterPeerID, pinInfo] of Object.entries(status.peerMap)) {
+    console.log(`    ${clusterPeerID}: ${pinInfo.status}`)
+  }
+}
+// e.g.
+// bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu:
+//     12D3KooWAjKw14hMUo7wdyEu9KwogrUFCCMiQZApgZ4zMcvtcacj: pinned
+//     12D3KooWKiebn7GqPvjqjKARnm47Xoez6f1civBEWxef3u5G6UdM: pinned
+//     12D3KooWLKdPdFx5UpPNwoVmMXsLULCDegAqXZ7RAgpKuPSMKoSS: pinned
+// bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy:
+//     12D3KooWAjKw14hMUo7wdyEu9KwogrUFCCMiQZApgZ4zMcvtcacj: queued
+//     12D3KooWKiebn7GqPvjqjKARnm47Xoez6f1civBEWxef3u5G6UdM: queued
+//     12D3KooWLKdPdFx5UpPNwoVmMXsLULCDegAqXZ7RAgpKuPSMKoSS: queued
+// ...etc.
+```
+
+Note: The method takes an options object that allows filtering by status e.g.
+
+```js
+// retrieve only pinning and pinned items
+await cluster.statusAll({ filter: ['pinning', 'pinned'] })
 ```
 
 ### `unpin`

--- a/README.md
+++ b/README.md
@@ -195,11 +195,14 @@ for (const status of statuses) {
 // ...etc.
 ```
 
-Note: The method takes an options object that allows filtering by status e.g.
+Note: The method takes an options object that allows filtering by status or cid e.g.
 
 ```js
 // retrieve only pinning and pinned items
 await cluster.statusAll({ filter: ['pinning', 'pinned'] })
+
+// retrieve status for the passed list of CIDs
+await cluster.statusAll({ cids: ['bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu'] })
 ```
 
 ### `unpin`

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ for (const [clusterPeerID, pinInfo] of Object.entries(status.peerMap)) {
 
 ### `statusAll`
 
-Status of all tracked CIDs.
+Status of all tracked CIDs. Note: this is an expensive operation. Use the optional filters when possible.
 
 ```js
 const statuses = await cluster.statusAll()
@@ -201,7 +201,7 @@ Note: The method takes an options object that allows filtering by status or cid 
 // retrieve only pinning and pinned items
 await cluster.statusAll({ filter: ['pinning', 'pinned'] })
 
-// retrieve status for the passed list of CIDs
+// retrieve status for the passed list of CIDs (requires Cluster version >= 0.14.5-rc1)
 await cluster.statusAll({ cids: ['bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu'] })
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   cluster0:
     container_name: cluster0
-    image: ipfs/ipfs-cluster:latest
+    image: ipfs/ipfs-cluster:v0.14.5-rc1
     depends_on:
       - ipfs0
     environment:
@@ -79,7 +79,7 @@ services:
 
   cluster1:
     container_name: cluster1
-    image: ipfs/ipfs-cluster:latest
+    image: ipfs/ipfs-cluster:v0.14.5-rc1
     depends_on:
       - ipfs1
     environment:
@@ -105,7 +105,7 @@ services:
 
   cluster2:
     container_name: cluster2
-    image: ipfs/ipfs-cluster:latest
+    image: ipfs/ipfs-cluster:v0.14.5-rc1
     depends_on:
       - ipfs2
     environment:

--- a/src/index.js
+++ b/src/index.js
@@ -408,7 +408,7 @@ export class Cluster {
   }
 
   /**
-   * Status of all tracked CIDs.
+   * Status of all tracked CIDs. Note: this is an expensive operation. Use the optional filters when possible.
    * @param {API.StatusAllOptions} [options]
    * @returns {Promise<API.StatusResponse[]>}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -342,7 +342,7 @@ export class Cluster {
   }
 
   /**
-   * Import a file to the cluster. First argument must be a `File` or `Blob`.
+   * Imports a file to the cluster. First argument must be a `File` or `Blob`.
    * Note: by default this module uses v1 CIDs and raw leaves enabled.
    * @param {File|Blob} file
    * @param {API.AddParams} [options]

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -149,8 +149,7 @@ export interface StatusOptions extends RequestOptions {
   local?: boolean
 }
 
-export interface StatusAllOptions extends RequestOptions {
-  local?: boolean
+export interface StatusAllOptions extends StatusOptions {
   filter?: TrackerStatus[]
 }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -149,6 +149,11 @@ export interface StatusOptions extends RequestOptions {
   local?: boolean
 }
 
+export interface StatusAllOptions extends RequestOptions {
+  local?: boolean
+  filter?: TrackerStatus[]
+}
+
 export type RecoverOptions = StatusOptions
 
 export type StatusResponse = {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -111,9 +111,9 @@ export type PinTypeShard = 5
  * PinType specifies which sort of Pin object we are dealing with.
  * In practice, the PinType decides how a Pin object is treated by the
  * PinTracker.
- * 
+ *
  * A sharded Pin would look like:
- * 
+ *
  * ```
  * [ Meta ] // (not pinned on IPFS, only present in cluster state)
  *   |

--- a/test/all.spec.js
+++ b/test/all.spec.js
@@ -4,7 +4,7 @@ import * as assert from 'uvu/assert'
 import fetch from '@web-std/fetch'
 import { FormData } from '@web-std/form-data'
 import { File, Blob } from '@web-std/file'
-import { Cluster, TrackerStatus } from '@nftstorage/ipfs-cluster'
+import { Cluster } from '@nftstorage/ipfs-cluster'
 import * as cluster from '@nftstorage/ipfs-cluster'
 import { CarWriter } from '@ipld/car'
 import * as CBOR from '@ipld/dag-cbor'
@@ -217,6 +217,7 @@ describe('cluster.pin', () => {
     assert.equal(status.cid, cid)
     for (const pinInfo of Object.values(status.peerMap)) {
       assert.ok(['pinning', 'pinned'].includes(pinInfo.status))
+      assertField(pinInfo, 'ipfsPeerId')
     }
   })
 })
@@ -324,9 +325,11 @@ describe('cluster.info', () => {
 })
 
 describe('cluster.statusAll', () => {
-  it('gets status for all items', async () => {
+  it('gets all statuses', async () => {
     const cluster = new Cluster(config.url, config)
-    const { cid } = await cluster.add(new File(['foo'], 'foo.txt'))
+    const { cid } = await cluster.add(
+      new File([`test-${Date.now()}`], 'test.txt')
+    )
 
     let found = false
     const statuses = await cluster.statusAll()
@@ -338,14 +341,14 @@ describe('cluster.statusAll', () => {
       assert.ok(Object.entries(status.peerMap).length > 0, 'missing peers')
       for (const [, pinInfo] of Object.entries(status.peerMap)) {
         assertField(pinInfo, 'status')
-        assertField(pinInfo, 'name')
+        assertField(pinInfo, 'peerName')
       }
     }
 
     assert.ok(found, `added content not found in status list: ${cid}`)
   })
 
-  it('gets filtered status', async () => {
+  it('gets statuses filtered by status', async () => {
     const cluster = new Cluster(config.url, config)
     // random junk - will not become pinned
     const junkCid = 'QmNm4jsipiQysHXZW5WHbH6RqPjGBnKPkagujXTPzpZ3zo'
@@ -353,24 +356,37 @@ describe('cluster.statusAll', () => {
 
     try {
       let found = false
-      /** @type {import('../src/interface').TrackerStatus[]} */
+      /** @type {import('@nftstorage/ipfs-cluster').API.FilterTrackerStatus[]} */
       const filter = ['pin_queued', 'pinning', 'pin_error']
       const statuses = await cluster.statusAll({ filter })
       for (const status of statuses) {
         assertField(status, 'cid')
-        if (status.cid === cid) {
+        if (status.cid === junkCid) {
           found = true
         }
-        assert.ok(Object.entries(status.peerMap).length > 0, 'missing peers')
         for (const [, pinInfo] of Object.entries(status.peerMap)) {
-          assertField(pinInfo, 'status')
-          assertField(pinInfo, 'name')
+          assert.ok(filter.includes(pinInfo.status))
         }
       }
 
-      assert.ok(found, `added content not found in status list: ${cid}`)
+      assert.ok(found, `junk CID not found in status list: ${junkCid}`)
     } finally {
       await cluster.unpin(junkCid)
+    }
+  })
+
+  it('gets statuses filtered by CID', async () => {
+    const cluster = new Cluster(config.url, config)
+    const f0 = await cluster.add(new File([`test0-${Date.now()}`], 'test0.txt'))
+    const f1 = await cluster.add(new File([`test1-${Date.now()}`], 'test1.txt'))
+    const f2 = await cluster.add(new File([`test2-${Date.now()}`], 'test2.txt'))
+
+    const statuses = await cluster.statusAll({ cids: [f0.cid, f1.cid] })
+    assert.equal(statuses.length, 2, 'returns status for 2 CIDs')
+    for (const status of statuses) {
+      assertField(status, 'cid')
+      assert.not.equal(status.cid, f2.cid)
+      assert.ok([f0.cid, f1.cid].includes(status.cid))
     }
   })
 })
@@ -381,6 +397,10 @@ describe('cluster.statusAll', () => {
  */
 const assertField = (info, key) => {
   const value = info[key]
-  assert.equal(typeof value, 'string', `${key} is a string`)
-  assert.ok(value.length || 0 > 0, `${key} is non empty string`)
+  assert.equal(
+    typeof value,
+    'string',
+    `expected ${key} is string but is: ${typeof value}`
+  )
+  assert.ok((value.length || 0) > 0, `${key} is not empty`)
 }


### PR DESCRIPTION
1. Adds `statusAll` method to get status for ALL pins. Note this is an expensive operation and results are buffered in memory. Use the filtering options `filter` and `cids` to reduce the result set. NOTE: only the latest Cluster version (v0.14.5-rc1) supports the `cids` filter.
2. Adds `ipfsPeerId` property to the `PeerInfo` type (which is part of the `peerMap` for status calls).
3. Refactors the enum pin types which were basically unusable in JS.

Also adds some missing method descriptions that got removed somehow.

BREAKING CHANGE: Types for `TrackerStatus` and `PinType` have changed from `enum` to string union. There are no runtime API alterations (only additions) so unless you're using those types directly in your project then you'll probably not notice any change.

