### PR TITLE
feat: add peerList method

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ Get a list of Cluster peer info.
 
 ```js
 const peers = await cluster.peerList()
-peers.forEach(peer => {
+peers.forEach((peer) => {
   console.log(`${peer.id} | ${peer.peerName}`)
   console.log('  > Addresses:')
-  peer.addresses.forEach(a => console.log(`    - ${a}`))
+  peer.addresses.forEach((a) => console.log(`    - ${a}`))
   console.log(`  > IPFS: ${peer.ipfs.id}`)
-  peer.ipfs.addresses.forEach(a => console.log(`    - ${a}`))
+  peer.ipfs.addresses.forEach((a) => console.log(`    - ${a}`))
 })
 ```
 
@@ -219,7 +219,9 @@ Note: The method takes an options object that allows filtering by status or cid 
 await cluster.statusAll({ filter: ['pinning', 'pinned'] })
 
 // retrieve status for the passed list of CIDs (requires Cluster version >= 0.14.5-rc1)
-await cluster.statusAll({ cids: ['bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu'] })
+await cluster.statusAll({
+  cids: ['bafybeigpsl667todjswabhelaxvwmk7amgg3txsv5tkcpbpj5rtrf6g7mu']
+})
 ```
 
 ### `unpin`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Object.assign(global, { fetch, File, Blob, FormData })
 
 ## API
 
-This library is **WIP** and not _all_ cluster HTTP API methods are available yet (PR's welcome!). Please see the [typescript types](https://github.com/nftstorage/ipfs-cluster/blob/main/index.d.ts) for full parameter and return types.
+This library is **WIP** and not _all_ cluster HTTP API methods are available yet (PR's welcome!). Please see the [typescript types](https://github.com/nftstorage/ipfs-cluster/blob/main/src/interface.ts) for full parameter and return types.
+
+Note: all methods take an options object with a `signal` property - an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) from an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) allowing the request to be aborted by the caller.
 
 - [Constructor](#constructor)
 - [`add`](#add)
@@ -52,8 +54,8 @@ This library is **WIP** and not _all_ cluster HTTP API methods are available yet
 - [`allocations`](#allocations)
 - `id`
 - `metrics`
-- [`metricNames`](#metricNames)
-- `peerList`
+- [`metricNames`](#metricnames)
+- [`peerList`](#peerlist)
 - `peerAdd`
 - `peerRemove`
 - [`pin`](#pin)
@@ -134,6 +136,21 @@ Get a list of metric types known to the peer.
 ```js
 const names = await cluster.metricNames()
 console.log(names) // [ 'ping', 'freespace' ]
+```
+
+### `peerList`
+
+Get a list of Cluster peer info.
+
+```js
+const peers = await cluster.peerList()
+peers.forEach(peer => {
+  console.log(`${peer.id} | ${peer.peerName}`)
+  console.log('  > Addresses:')
+  peer.addresses.forEach(a => console.log(`    - ${a}`))
+  console.log(`  > IPFS: ${peer.ipfs.id}`)
+  peer.ipfs.addresses.forEach(a => console.log(`    - ${a}`))
+})
 ```
 
 ### `pin`

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ const peers = await cluster.peerList()
 peers.forEach((peer) => {
   console.log(`${peer.id} | ${peer.peerName}`)
   console.log('  > Addresses:')
-  peer.addresses.forEach((a) => console.log(`    - ${a}`))
+  peer.addresses.forEach((addr) => console.log(`    - ${addr}`))
   console.log(`  > IPFS: ${peer.ipfs.id}`)
-  peer.ipfs.addresses.forEach((a) => console.log(`    - ${a}`))
+  peer.ipfs.addresses.forEach((addr) => console.log(`    - ${addr}`))
 })
 ```
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -192,7 +192,7 @@ export type PinInfo = {
   ipfsPeerId: string
   status: TrackerStatus
   timestamp: Date
-  error: string
+  error?: string
 }
 
 /**
@@ -269,9 +269,12 @@ export type FilterTrackerStatus = TrackerStatus | TrackerStatusUndefined
 export interface PeerInfo {
   id: string
   addresses: string[]
+  error?: string
 }
 
 export interface ClusterInfo extends PeerInfo {
+  id: string
+  addresses: string[]
   version: string
   commit: string
   peerName: string
@@ -279,4 +282,5 @@ export interface ClusterInfo extends PeerInfo {
   clusterPeers: string[]
   clusterPeersAddresses: string[]
   ipfs: PeerInfo
+  error?: string
 }

--- a/test/all.spec.js
+++ b/test/all.spec.js
@@ -288,39 +288,28 @@ describe('cluster auth', () => {
 })
 
 describe('cluster.info', () => {
-  /**
-   * @param {cluster.API.ClusterInfo} info
-   */
-  const assertInfo = (info) => {
-    assertField(info, 'id')
-    assertField(info, 'version')
-    assert.equal(typeof info.commit, 'string')
-    assertField(info, 'peerName')
-    assertField(info, 'rpcProtocolVersion')
-    assert.ok(Array.isArray(info.addresses), 'addresses is array')
-    assert.ok(Array.isArray(info.clusterPeers), 'clusterPeers is an array')
-    assert.ok(
-      Array.isArray(info.clusterPeersAddresses),
-      'clusterPeersAddresses is array'
-    )
-
-    const { ipfs } = info
-
-    assertField(ipfs, 'id')
-    assert.ok(ipfs.addresses)
-    assert.equal(typeof info.version, 'string', 'version is a string')
-    assert.ok(info.version.length > 0, 'version is non empty string')
-  }
-
   it('gets cluster id (static)', async () => {
     const info = await cluster.info(config)
     assertInfo(info)
   })
 
-  it('gets cluster version (method)', async () => {
+  it('gets cluster id (method)', async () => {
     const cluster = new Cluster(config.url, config)
     const info = await cluster.info()
     assertInfo(info)
+  })
+})
+
+describe('cluster.peerList', () => {
+  it('gets cluster peerList (static)', async () => {
+    const list = await cluster.peerList(config)
+    list.forEach(assertInfo)
+  })
+
+  it('gets cluster peerList (method)', async () => {
+    const cluster = new Cluster(config.url, config)
+    const list = await cluster.peerList()
+    list.forEach(assertInfo)
   })
 })
 
@@ -403,4 +392,28 @@ const assertField = (info, key) => {
     `expected ${key} is string but is: ${typeof value}`
   )
   assert.ok((value.length || 0) > 0, `${key} is not empty`)
+}
+
+/**
+ * @param {cluster.API.ClusterInfo} info
+ */
+const assertInfo = (info) => {
+  assertField(info, 'id')
+  assertField(info, 'version')
+  assert.equal(typeof info.commit, 'string')
+  assertField(info, 'peerName')
+  assertField(info, 'rpcProtocolVersion')
+  assert.ok(Array.isArray(info.addresses), 'addresses is array')
+  assert.ok(Array.isArray(info.clusterPeers), 'clusterPeers is an array')
+  assert.ok(
+    Array.isArray(info.clusterPeersAddresses),
+    'clusterPeersAddresses is array'
+  )
+
+  const { ipfs } = info
+
+  assertField(ipfs, 'id')
+  assert.ok(ipfs.addresses)
+  assert.equal(typeof info.version, 'string', 'version is a string')
+  assert.ok(info.version.length > 0, 'version is non empty string')
 }


### PR DESCRIPTION
This PR adds the `peerList` method for listing info about all peers in a cluster.

https://github.com/ipfs/ipfs-cluster/blob/d01fcdf25c7b6c45068f791e6094faf7600624c4/api/rest/restapi.go#L89-L94