### PR TITLE
fix: no more object with slash for CID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   cluster0:
     container_name: cluster0
-    image: ipfs/ipfs-cluster:v1.0.0-rc3
+    image: ipfs/ipfs-cluster:v1.0.0-rc4
     depends_on:
       - ipfs0
     environment:
@@ -79,7 +79,7 @@ services:
 
   cluster1:
     container_name: cluster1
-    image: ipfs/ipfs-cluster:v1.0.0-rc3
+    image: ipfs/ipfs-cluster:v1.0.0-rc4
     depends_on:
       - ipfs1
     environment:
@@ -105,7 +105,7 @@ services:
 
   cluster2:
     container_name: cluster2
-    image: ipfs/ipfs-cluster:v1.0.0-rc3
+    image: ipfs/ipfs-cluster:v1.0.0-rc4
     depends_on:
       - ipfs2
     environment:

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ export const add = async (cluster, file, options = {}) => {
       signal: options.signal
     })
     const data = params['stream-channels'] ? result : result[0]
-    return { ...data, cid: data.cid['/'] }
+    return { ...data, cid: data.cid }
   } catch (err) {
     const error = /** @type {Error & {response?:Response}}  */ (err)
     if (error.response?.ok) {
@@ -117,10 +117,6 @@ export const addDirectory = async (cluster, files, options = {}) => {
     body,
     signal: options.signal
   })
-
-  for (const f of results) {
-    f.cid = f.cid['/']
-  }
 
   return results
 }
@@ -560,7 +556,7 @@ const toPinResponse = (data) => {
     expireAt: new Date(data.expire_at),
     metadata: data.metadata,
     pinUpdate: data.pin_update,
-    cid: data.cid['/'],
+    cid: data.cid,
     type: data.type,
     allocations: data.allocations,
     maxDepth: data.max_depth,
@@ -588,7 +584,7 @@ const toStatusResponse = (data) => {
       ])
     )
   }
-  return { cid: data.cid['/'], name: data.name, peerMap }
+  return { cid: data.cid, name: data.name, peerMap }
 }
 
 /**


### PR DESCRIPTION
As of ipfs-cluster@1.0.0-rc.4 

> Cids are JSON-ified as '"Qm...."' instead of '{ "/": "Qm....." }'

see: https://github.com/ipfs/ipfs-cluster/pull/1626